### PR TITLE
Fix Android crash (use 'each' instead of 'forEach') & GitHub Actions builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,8 +100,8 @@ task jarAndroid {
         //d8 doesn't work on windows (but required for Actions), so it set it to d8.bat if needed.
         def d8command = isWindows() ? "d8.bat" : "d8"
 
-        //dex and desugar files
-        """$sdkRoot/build-tools/30.0.3/$d8command $dependencies --min-api 14 --output 
+        //dex and desugar files - require d8 in your path
+        """$d8command $dependencies --min-api 14 --output 
             ${project.archivesBaseName}Android.jar ${project.archivesBaseName}Desktop.jar"""
             .execute(null, new File("$buildDir/libs")).waitForProcessOutput(System.out, System.err)
     }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ sourceSets.main {
 ext {
     ME13CoreVersion = 'v1.5'
     modCoreVersion = '1.0.6b'
-    mindustryVersion = 'v144.3'
+    mindustryVersion = 'v145'
     jabelVersion = "93fde537c7"
     sdkRoot = System.getenv("ANDROID_HOME") ?: System.getenv("ANDROID_SDK_ROOT")
 }
@@ -97,11 +97,18 @@ task jarAndroid {
             "--classpath $it.path"
         }.join(" ")
 
-        //dex and desugar files - this requires d8 in your PATH
-        """$sdkRoot/build-tools/30.0.3/d8.bat $dependencies --min-api 14 --output 
-${project.archivesBaseName}Android.jar ${project.archivesBaseName}Desktop.jar"""
+        //d8 doesn't work on windows (but required for Actions), so it set it to d8.bat if needed.
+        def d8command = isWindows() ? "d8.bat" : "d8"
+
+        //dex and desugar files
+        """$sdkRoot/build-tools/30.0.3/$d8command $dependencies --min-api 14 --output 
+            ${project.archivesBaseName}Android.jar ${project.archivesBaseName}Desktop.jar"""
             .execute(null, new File("$buildDir/libs")).waitForProcessOutput(System.out, System.err)
     }
+}
+
+def isWindows() {
+    return System.properties['os.name'].toLowerCase().contains('win')
 }
 
 jar {

--- a/src/me13/me/MaterialEnergy.java
+++ b/src/me13/me/MaterialEnergy.java
@@ -58,7 +58,7 @@ public class MaterialEnergy extends Mod {
         MeBlocks.load();
         MeTech.load();
 
-        Vars.content.blocks().forEach(block -> {
+        Vars.content.blocks().each(block -> {
             if(block.name.startsWith("me-erekir-")) {
                 String n = block.name.replace("erekir-", "");
                 block.localizedName = Core.bundle.get("block." + n + ".name");

--- a/src/me13/me/integration/MaterialEnergyInvoker.java
+++ b/src/me13/me/integration/MaterialEnergyInvoker.java
@@ -49,7 +49,7 @@ public class MaterialEnergyInvoker {
         BuildingMixins.register(Terminal.TerminalBuild.class, NO_STORAGE_MIXIN);
         BuildingMixins.register(EIBus.EIBusBuild.class, NO_STORAGE_MIXIN);
 
-        Vars.content.blocks().forEach(block -> {
+        Vars.content.blocks().each(block -> {
             if(block.name.startsWith("me-") && BuildingMixins.isMeBuilding(block.buildType.get())) {
                 BuildingMixins.meBlocks.add(block);
             }
@@ -80,7 +80,7 @@ public class MaterialEnergyInvoker {
             }
         });
 
-        Vars.content.items().forEach(item -> {
+        Vars.content.items().each(item -> {
             BoxMixins.register(new IMeBoxMixin() {
                 @Override
                 public String name() {
@@ -104,7 +104,7 @@ public class MaterialEnergyInvoker {
             });
         });
 
-        Vars.content.liquids().forEach(liquid -> {
+        Vars.content.liquids().each(liquid -> {
             BoxMixins.register(new IMeBoxMixin() {
                 @Override
                 public String name() {

--- a/src/me13/me/net/Netting.java
+++ b/src/me13/me/net/Netting.java
@@ -35,13 +35,13 @@ public class Netting {
         Seq<Building> result = new Seq<>();
         var mixin = BuildingMixins.getMixin(building);
         if(mixin != null) {
-            mixin.getChildren(building).forEach(build -> {
+            mixin.getChildren(building).each(build -> {
                 if(inNet(build, building)) {
                     result.add(build);
                 }
             });
         } else if(building.enabled()) {
-            building.proximity.forEach(build -> {
+            building.proximity.each(build -> {
                 if(inNet(build, building)) {
                     result.add(build);
                 }
@@ -51,7 +51,7 @@ public class Netting {
     }
 
     public static void getConnections(Building source, Seq<Building> buildings) {
-        getConnections(source).forEach(b -> {
+        getConnections(source).each(b -> {
             if(!buildings.contains(b)) {
                 buildings.add(b);
                 getConnections(b, buildings);
@@ -95,13 +95,13 @@ public class Netting {
             var host2 = mixin.getMixinBuild(building);
             var host = host2 == null ? building : host2;
             mixins.addAll(mixin.getMixinsSelf(host));
-            NetMixins.getMixins().forEach(mixin2 -> {
+            NetMixins.getMixins().each(mixin2 -> {
                 if(mixin.canUseMixin(host, mixin2) && mixin2.haveMixinIn(host)) {
                     mixins.add(mixin2);
                 }
             });
         } else {
-            NetMixins.getMixins().forEach(mixin2 -> {
+            NetMixins.getMixins().each(mixin2 -> {
                 if(mixin2.haveMixinIn(building)) {
                     mixins.add(mixin2);
                 }
@@ -119,7 +119,7 @@ public class Netting {
             var mixin2 = BuildingMixins.getMixin(build);
             if(mixin2 == null) {
                 var mixins = getMixinsOf(build);
-                mixins.forEach(mixin3 -> {
+                mixins.each(mixin3 -> {
                     if(mixin3.getClass() == mixin || mixin3.getClass().getSuperclass() == mixin) {
                         cons.get((T) mixin3, build);
                     }
@@ -128,7 +128,7 @@ public class Netting {
                 var host2 = mixin2.getMixinBuild(build);
                 var host = host2 == null ? build : host2;
                 var mixins = getMixinsOf(host);
-                mixins.forEach(mixin3 -> {
+                mixins.each(mixin3 -> {
                     if(mixin3.getClass() == mixin || mixin3.getClass().getSuperclass() == mixin) {
                         cons.get((T) mixin3, host);
                     }

--- a/src/me13/me/ui/TerminalDialog.java
+++ b/src/me13/me/ui/TerminalDialog.java
@@ -41,7 +41,7 @@ public class TerminalDialog extends BaseDialog {
                 int cols = (int) ((Core.scene.getWidth()*0.8)/200);
                 final int[] i = {0};
                 pane[0].clearChildren();
-                BoxMixins.getMixins().forEach(mixin -> {
+                BoxMixins.getMixins().each(mixin -> {
                     mixin.buildTerminal(pane[0], building);
                     if(++i[0] % cols == 0) {
                         pane[0].row();


### PR DESCRIPTION
Android doesn't support the `forEach()` function, use instead the `each()` function.
GitHub Actions doesn't use `d8.bat` but `d8`, I made a function that use `d8.bat` if on Windows, else use `d8`.

I tested locally on my phone and it does load properly.


Required Pull Request: https://github.com/MindustryExtended13/Me13Core/pull/1